### PR TITLE
Margin issue

### DIFF
--- a/apps/flipbook/src/components/atoms/AddPage.tsx
+++ b/apps/flipbook/src/components/atoms/AddPage.tsx
@@ -22,7 +22,7 @@ export const AddPage = (
 const FlipBookPage: React.FC<{ right?: boolean }> = ({ right, children }) => {
     return (
         <div className="page">
-            <div className={`prose flex flex-col p-8 ${right ? 'pr-12' : 'pl-12'}`}>{children}</div>
+            <div className={`prose flex flex-col p-8 m-0 max-w-none ${right ? 'pr-12' : 'pl-12'}`}>{children}</div>
         </div>
     );
 };

--- a/apps/flipbook/src/components/atoms/AddPage.tsx
+++ b/apps/flipbook/src/components/atoms/AddPage.tsx
@@ -19,17 +19,19 @@ export const AddPage = (
     loc!.appendChild(page);
 };
 
-const FlipBookPage: React.FC<{ right?: boolean }> = ({ right, children }) => {
+const FlipBookPage: React.FC = ({ children }) => {
     return (
         <div className="page">
-            <div className={`prose flex flex-col p-8 m-0 max-w-none ${right ? 'pr-12' : 'pl-12'}`}>{children}</div>
+            <div className="max-w-none flex">
+                <div className={`prose flex flex-col p-8 m-0`}>{children}</div>
+            </div>
         </div>
     );
 };
 
-const PlainPage: React.FC<{ content: string; right?: boolean }> = ({ content, right }) => {
+const PlainPage: React.FC<{ content: string }> = ({ content }) => {
     return (
-        <FlipBookPage right={right}>
+        <FlipBookPage>
             <div dangerouslySetInnerHTML={{ __html: content }}></div>
         </FlipBookPage>
     );
@@ -53,6 +55,6 @@ const AddReactPage = ({ element }: { element: React.ReactElement }) => {
 
 export const AddPageImage = ({ content, src }: { content: string; src: string }) =>
     AddReactPage({ element: <PageImageComponent content={content} src={src} /> });
-export const AddPlainPage = ({ content, right }: { content: string; right?: boolean }) => {
-    AddReactPage({ element: <PlainPage right={right} content={content} /> });
+export const AddPlainPage = ({ content }: { content: string }) => {
+    AddReactPage({ element: <PlainPage content={content} /> });
 };

--- a/apps/flipbook/src/components/organism/flipbook.tsx
+++ b/apps/flipbook/src/components/organism/flipbook.tsx
@@ -46,7 +46,7 @@ export const FlipBook: React.FC<IFlipBook> = ({ pages, graduate, science }) => {
         pages.sort((a, b) => a?.changedToMatter.pageNumber - b?.changedToMatter.pageNumber);
         let loc = document.getElementById('page-storage');
         pages.map((p) => {
-            AddPlainPage({ content: p.clean, right: index % 2 === 0 });
+            AddPlainPage({ content: p.clean });
             index++;
         });
         AddFrontPage(

--- a/apps/flipbook/src/styles/globals.css
+++ b/apps/flipbook/src/styles/globals.css
@@ -4,5 +4,4 @@
 
 .page-content {
     @apply prose;
-    padding-left: 20px;
 }

--- a/apps/flipbook/src/styles/styleBook.tsx
+++ b/apps/flipbook/src/styles/styleBook.tsx
@@ -48,7 +48,9 @@ export const Wrapper = styled.div`
 
     .page {
         background-color: white;
-        overflow: auto;
+        overflow: hidden;
+        padding-left: 3ch;
+        padding-right: 3ch;
         h1,
         h2,
         h3,
@@ -61,13 +63,18 @@ export const Wrapper = styled.div`
             // for left page (property will be added automatically)
             border-right: 2px solid rgba(0, 0, 0, 0.1);
             box-shadow: inset 5px 0px 0px 1px rgba(0, 0, 0, 0.1);
+            * {
+                justify-content: start;
+            }
         }
 
         &.--right {
             // for right page (property will be added automatically)
             border-left: 0;
             box-shadow: inset 5px 0px 0px 1px rgba(0, 0, 0, 0.1);
-
+            * {
+                justify-content: end;
+            }
             .page-footer {
                 text-align: right;
             }


### PR DESCRIPTION
#31 Wykonany, chociaż osobiście moje oko skłonne jest do identycznych odstępów po lewej i prawej stronie kontentu.
Zmiany:
 - usunięte niepotrzebne zmienne right (flipbook sam wpasowuje jaka to strona),
 - odstępy wykonane na divach w klasie page ponieważ nie dało się zmienić na display:flex :( ;
 - usunięte nieużywane wyrażenie w globals.css
 
![image](https://user-images.githubusercontent.com/58345037/154360165-1bc1b99a-4da5-4f27-8bc8-dac3616fa4ce.png)
